### PR TITLE
[state/execution] Remove invalid txs from ResponseCreateBlock

### DIFF
--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -47,7 +47,7 @@ func (emptyMempool) TxsWaitChan() <-chan struct{} { return nil }
 
 func (emptyMempool) InitWAL() error                                      { return nil }
 func (emptyMempool) CloseWAL()                                           {}
-func (emptyMempool) RemoveTxs(_ types.Txs, _ []*abcix.ResponseDeliverTx) {}
+func (emptyMempool) RemoveTxs(_ types.Txs) error { return nil }
 
 //-----------------------------------------------------------------------------
 

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -45,8 +45,8 @@ func (emptyMempool) TxsBytes() int64               { return 0 }
 func (emptyMempool) TxsFront() *clist.CElement    { return nil }
 func (emptyMempool) TxsWaitChan() <-chan struct{} { return nil }
 
-func (emptyMempool) InitWAL() error                                      { return nil }
-func (emptyMempool) CloseWAL()                                           {}
+func (emptyMempool) InitWAL() error              { return nil }
+func (emptyMempool) CloseWAL()                   {}
 func (emptyMempool) RemoveTxs(_ types.Txs) error { return nil }
 
 //-----------------------------------------------------------------------------

--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -45,8 +45,9 @@ func (emptyMempool) TxsBytes() int64               { return 0 }
 func (emptyMempool) TxsFront() *clist.CElement    { return nil }
 func (emptyMempool) TxsWaitChan() <-chan struct{} { return nil }
 
-func (emptyMempool) InitWAL() error { return nil }
-func (emptyMempool) CloseWAL()      {}
+func (emptyMempool) InitWAL() error                                      { return nil }
+func (emptyMempool) CloseWAL()                                           {}
+func (emptyMempool) RemoveTxs(_ types.Txs, _ []*abcix.ResponseDeliverTx) {}
 
 //-----------------------------------------------------------------------------
 

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -192,7 +192,7 @@ func (mem *CListMempool) TxsBytes() int64 {
 	return atomic.LoadInt64(&mem.txsBytes)
 }
 
-// Lock() must be help by the caller during execution.
+// Lock() must be held by the caller during execution.
 func (mem *CListMempool) FlushAppConn() error {
 	return mem.proxyAppConn.FlushSync()
 }
@@ -580,7 +580,7 @@ func (mem *CListMempool) ReapMaxTxs(max int) types.Txs {
 	return txs
 }
 
-// Lock() must be help by the caller during execution.
+// Lock() must be held by the caller during execution.
 func (mem *CListMempool) Update(
 	height int64,
 	txs types.Txs,
@@ -701,7 +701,7 @@ func (mem *CListMempool) GetNextTxBytes(remainBytes int64, remainGas int64, star
 	return candidate.Value.(*mempoolTx).tx, nil
 }
 
-// Lock() must be help by the caller during execution.
+// Lock() must be held by the caller during execution.
 func (mem *CListMempool) RemoveTxs(txs types.Txs) error {
 	for _, tx := range txs {
 		mem.cache.Remove(tx)

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"container/list"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -700,30 +701,18 @@ func (mem *CListMempool) GetNextTxBytes(remainBytes int64, remainGas int64, star
 	return candidate.Value.(*mempoolTx).tx, nil
 }
 
-func (mem *CListMempool) RemoveTxs(txs types.Txs, deliverTxResponses []*abcix.ResponseDeliverTx) {
-	for i, tx := range txs {
-		if deliverTxResponses[i].Code == abcix.CodeTypeOK {
-			// Add valid committed tx to the cache (if missing).
-			_ = mem.cache.Push(tx)
-		} else {
-			// Allow invalid transactions to be resubmitted.
-			mem.cache.Remove(tx)
-		}
+// Lock() must be help by the caller during execution.
+func (mem *CListMempool) RemoveTxs(txs types.Txs) error {
+	for _, tx := range txs {
+		mem.cache.Remove(tx)
 
-		// Remove committed tx from the mempool.
-		//
-		// Note an evil proposer can drop valid txs!
-		// Mempool before:
-		//   100 -> 101 -> 102
-		// Block, proposed by an evil proposer:
-		//   101 -> 102
-		// Mempool after:
-		//   100
-		// https://github.com/tendermint/tendermint/issues/3322.
-		if e, ok := mem.txsMap.Load(TxKey(tx)); ok {
-			mem.removeTx(tx, e.(*clist.CElement), false)
+		e, ok := mem.txsMap.Load(TxKey(tx))
+		if !ok {
+			return errors.New("fail to load tx from mempool")
 		}
+		mem.removeTx(tx, e.(*clist.CElement), false)
 	}
+	return nil
 }
 
 //--------------------------------------------------------------------------------

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -644,3 +644,26 @@ func abciResponses(n int, code uint32) []*abcix.ResponseDeliverTx {
 	}
 	return responses
 }
+
+func TestCListMempool_RemoveTxs(t *testing.T) {
+	app := kvstore.NewApplication()
+	cc := proxy.NewLegacyLocalClientCreator(app)
+	mempool, cleanup := newMempoolWithApp(cc)
+	defer cleanup()
+
+	txs := []types.Tx{[]byte{0x01}, []byte{0x02}}
+	mempool.CheckTx(txs[0], nil, TxInfo{})
+	mempool.CheckTx(txs[1], nil, TxInfo{})
+	assert.EqualValues(t, 2, mempool.TxsBytes())
+
+	err := mempool.RemoveTxs(txs[1:])
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, mempool.TxsBytes())
+
+	err = mempool.RemoveTxs(txs[0:1])
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, mempool.TxsBytes())
+
+	err = mempool.RemoveTxs(txs[1:])
+	require.Error(t, err)
+}

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -644,7 +644,3 @@ func abciResponses(n int, code uint32) []*abcix.ResponseDeliverTx {
 	}
 	return responses
 }
-
-func TestCListMempool_RemoveTxs(t *testing.T) {
-
-}

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -656,14 +656,11 @@ func TestCListMempool_RemoveTxs(t *testing.T) {
 	mempool.CheckTx(txs[1], nil, TxInfo{})
 	assert.EqualValues(t, 2, mempool.TxsBytes())
 
+	for i := range txs {
+		err := mempool.RemoveTxs(txs[i : i+1])
+		require.NoError(t, err)
+		assert.EqualValues(t, 1-i, mempool.TxsBytes())
+	}
 	err := mempool.RemoveTxs(txs[1:])
-	require.NoError(t, err)
-	assert.EqualValues(t, 1, mempool.TxsBytes())
-
-	err = mempool.RemoveTxs(txs[0:1])
-	require.NoError(t, err)
-	assert.EqualValues(t, 0, mempool.TxsBytes())
-
-	err = mempool.RemoveTxs(txs[1:])
 	require.Error(t, err)
 }

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -644,3 +644,7 @@ func abciResponses(n int, code uint32) []*abcix.ResponseDeliverTx {
 	}
 	return responses
 }
+
+func TestCListMempool_RemoveTxs(t *testing.T) {
+
+}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -81,6 +81,8 @@ type Mempool interface {
 	// CloseWAL closes and discards the underlying WAL file.
 	// Any further writes will not be relayed to disk.
 	CloseWAL()
+
+	RemoveTxs(blockTxs types.Txs, deliverTxResponses []*abcix.ResponseDeliverTx)
 }
 
 //--------------------------------------------------------------------------------

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -82,6 +82,7 @@ type Mempool interface {
 	// Any further writes will not be relayed to disk.
 	CloseWAL()
 
+	// RemoveTxs removes invalid txs from mempool included in ResponseCreateBlock
 	RemoveTxs(blockTxs types.Txs) error
 }
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -82,7 +82,7 @@ type Mempool interface {
 	// Any further writes will not be relayed to disk.
 	CloseWAL()
 
-	RemoveTxs(blockTxs types.Txs, deliverTxResponses []*abcix.ResponseDeliverTx)
+	RemoveTxs(blockTxs types.Txs) error
 }
 
 //--------------------------------------------------------------------------------

--- a/mempool/mock/mempool.go
+++ b/mempool/mock/mempool.go
@@ -41,6 +41,6 @@ func (Mempool) TxsBytes() int64               { return 0 }
 func (Mempool) TxsFront() *clist.CElement    { return nil }
 func (Mempool) TxsWaitChan() <-chan struct{} { return nil }
 
-func (Mempool) InitWAL() error                                      { return nil }
-func (Mempool) CloseWAL()                                           {}
+func (Mempool) InitWAL() error              { return nil }
+func (Mempool) CloseWAL()                   {}
 func (Mempool) RemoveTxs(_ types.Txs) error { return nil }

--- a/mempool/mock/mempool.go
+++ b/mempool/mock/mempool.go
@@ -41,5 +41,6 @@ func (Mempool) TxsBytes() int64               { return 0 }
 func (Mempool) TxsFront() *clist.CElement    { return nil }
 func (Mempool) TxsWaitChan() <-chan struct{} { return nil }
 
-func (Mempool) InitWAL() error { return nil }
-func (Mempool) CloseWAL()      {}
+func (Mempool) InitWAL() error                                      { return nil }
+func (Mempool) CloseWAL()                                           {}
+func (Mempool) RemoveTxs(_ types.Txs, _ []*abcix.ResponseDeliverTx) {}

--- a/mempool/mock/mempool.go
+++ b/mempool/mock/mempool.go
@@ -43,4 +43,4 @@ func (Mempool) TxsWaitChan() <-chan struct{} { return nil }
 
 func (Mempool) InitWAL() error                                      { return nil }
 func (Mempool) CloseWAL()                                           {}
-func (Mempool) RemoveTxs(_ types.Txs, _ []*abcix.ResponseDeliverTx) {}
+func (Mempool) RemoveTxs(_ types.Txs) error { return nil }

--- a/state/execution.go
+++ b/state/execution.go
@@ -117,17 +117,16 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	}
 
 	// remove invalid txs from mempool
-	blockExec.mempool.Lock()
-	defer blockExec.mempool.Unlock()
-
 	var invalidTxs = make([]types.Tx, len(resp.InvalidTxs))
-	var deliverTxResponses = make([]*abcix.ResponseDeliverTx, len(resp.InvalidTxs))
 	for i, invalidTx := range resp.InvalidTxs {
 		copy(invalidTxs[i], invalidTx)
-		deliverTxResponses[i].Code = 1
 	}
-
-	blockExec.mempool.RemoveTxs(invalidTxs, deliverTxResponses)
+	blockExec.mempool.Lock()
+	err = blockExec.mempool.RemoveTxs(invalidTxs)
+	if err != nil {
+		panic(err)
+	}
+	blockExec.mempool.Unlock()
 
 	for _, txBytes := range resp.Txs {
 		txs = append(txs, txBytes)

--- a/state/execution.go
+++ b/state/execution.go
@@ -115,6 +115,25 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	if err != nil {
 		panic(err)
 	}
+
+	// remove invalid txs from mempool
+	var invalidTxs = make([]types.Tx, len(resp.InvalidTxs))
+	var deliverTxResponses = make([]*abcix.ResponseDeliverTx, len(resp.InvalidTxs))
+	for i, tx := range resp.InvalidTxs {
+		copy(invalidTxs[i], tx)
+		deliverTxResponses[i].Code = 1
+	}
+	err = blockExec.mempool.Update(
+		height,
+		invalidTxs,
+		deliverTxResponses,
+		TxPreCheck(state),
+		TxPostCheck(state),
+	)
+	if err != nil {
+		panic(err)
+	}
+
 	for _, txBytes := range resp.Txs {
 		txs = append(txs, txBytes)
 	}

--- a/state/execution.go
+++ b/state/execution.go
@@ -124,7 +124,7 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	blockExec.mempool.Lock()
 	err = blockExec.mempool.RemoveTxs(invalidTxs)
 	if err != nil {
-		panic(err)
+		blockExec.logger.Error("Error in mempool.RemoveTxs", "err", err)
 	}
 	blockExec.mempool.Unlock()
 

--- a/state/execution.go
+++ b/state/execution.go
@@ -119,8 +119,8 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	// remove invalid txs from mempool
 	var invalidTxs = make([]types.Tx, len(resp.InvalidTxs))
 	var deliverTxResponses = make([]*abcix.ResponseDeliverTx, len(resp.InvalidTxs))
-	for i, tx := range resp.InvalidTxs {
-		copy(invalidTxs[i], tx)
+	for i, invalidTx := range resp.InvalidTxs {
+		copy(invalidTxs[i], invalidTx)
 		deliverTxResponses[i].Code = 1
 	}
 	err = blockExec.mempool.Update(

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -39,23 +39,20 @@ func TestCreateProposalBlock_MempoolRemoveTxs(t *testing.T) {
 	config := cfg.ResetTestRoot("node_create_proposal")
 	defer os.RemoveAll(config.RootDir)
 	app := &testApp{}
-	cc := proxy.NewLocalClientCreator(app)
-	proxyApp := proxy.NewAppConns(cc)
+	proxyApp := proxy.NewAppConns(proxy.NewLocalClientCreator(app))
 	err := proxyApp.Start()
 	require.Nil(t, err)
-	defer proxyApp.Stop() //nolint:errcheck // ignore for tests
+	defer proxyApp.Stop()
 
 	logger := log.TestingLogger()
 	state, stateDB, _ := makeState(1, 1)
 	proposerAddr, _ := state.Validators.GetByIndex(0)
 
-	// Make Mempool
 	mempool := mempl.NewCListMempool(
 		config.Mempool,
 		proxyApp.Mempool(),
 		state.LastBlockHeight,
 	)
-	mempool.SetLogger(logger)
 
 	txs := []types.Tx{[]byte{0x01}, []byte{0x02}, []byte{0x03}}
 	for i, tx := range txs {
@@ -90,7 +87,7 @@ func TestCreateProposalBlock_MempoolRemoveTxs(t *testing.T) {
 
 	tx, err = mempool.GetNextTxBytes(2, 1, tx)
 	assert.NoError(t, err)
-	assert.EqualValues(t, []byte(nil), tx)
+	assert.Nil(t, tx)
 }
 
 func TestApplyBlock(t *testing.T) {

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -87,6 +87,10 @@ func TestCreateProposalBlock_MempoolRemoveTxs(t *testing.T) {
 	tx, err := mempool.GetNextTxBytes(2, 1, nil)
 	assert.NoError(t, err)
 	assert.EqualValues(t, []byte{0x03}, tx)
+
+	tx, err = mempool.GetNextTxBytes(2, 1, tx)
+	assert.NoError(t, err)
+	assert.EqualValues(t, []byte(nil), tx)
 }
 
 func TestApplyBlock(t *testing.T) {

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -33,7 +33,7 @@ var (
 	nTxsPerBlock        = 10
 )
 
-func TestCreateProposalBlock(t *testing.T) {
+func TestCreateProposalBlock_MempoolRemoveTxs(t *testing.T) {
 	var invalidTxs = [][]byte{{0x01}, {0x02}}
 	mockProxyApp := &mocks.AppConnConsensus{}
 
@@ -51,22 +51,18 @@ func TestCreateProposalBlock(t *testing.T) {
 	proposerAddr, _ := state.Validators.GetByIndex(0)
 
 	// Make Mempool
-	memplMetrics := mempl.PrometheusMetrics("node_test")
 	mempool := mempl.NewCListMempool(
 		config.Mempool,
 		proxyApp.Mempool(),
 		state.LastBlockHeight,
-		mempl.WithMetrics(memplMetrics),
-		mempl.WithPreCheck(sm.TxPreCheck(state)),
-		mempl.WithPostCheck(sm.TxPostCheck(state)),
 	)
 	mempool.SetLogger(logger)
 
 	txs := []types.Tx{[]byte{0x01}, []byte{0x02}, []byte{0x03}}
-	for j, tx := range txs {
+	for i, tx := range txs {
 		err := mempool.CheckTx(tx, nil, mempl.TxInfo{})
 		assert.NoError(t, err)
-		assert.EqualValues(t, j+1, mempool.TxsBytes())
+		assert.EqualValues(t, i+1, mempool.TxsBytes())
 	}
 
 	blockExec := sm.NewBlockExecutor(

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -34,7 +34,6 @@ var (
 )
 
 func TestCreateProposalBlock_MempoolRemoveTxs(t *testing.T) {
-	var invalidTxs = [][]byte{{0x01}, {0x02}}
 	mockProxyApp := &mocks.AppConnConsensus{}
 
 	config := cfg.ResetTestRoot("node_create_proposal")
@@ -74,7 +73,7 @@ func TestCreateProposalBlock_MempoolRemoveTxs(t *testing.T) {
 	)
 	mockProxyApp.On("CreateBlockSync", tmock.Anything, tmock.Anything).Return(&abcix.ResponseCreateBlock{
 		Txs:        [][]byte{{0x03}},
-		InvalidTxs: invalidTxs,
+		InvalidTxs: [][]byte{{0x01}, {0x02}},
 	}, nil)
 
 	commit := types.NewCommit(0, 0, types.BlockID{}, nil)

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -78,14 +78,12 @@ func TestCreateProposalBlock_MempoolRemoveTxs(t *testing.T) {
 	}, nil)
 
 	commit := types.NewCommit(0, 0, types.BlockID{}, nil)
-	block, _ := blockExec.CreateProposalBlock(
+	blockExec.CreateProposalBlock(
 		1,
 		state, commit,
 		proposerAddr,
 	)
 	assert.EqualValues(t, 1, mempool.TxsBytes())
-	err = blockExec.ValidateBlock(state, block)
-	assert.NoError(t, err)
 }
 
 func TestApplyBlock(t *testing.T) {

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -77,14 +77,15 @@ func TestCreateProposalBlock_MempoolRemoveTxs(t *testing.T) {
 	}, nil)
 
 	commit := types.NewCommit(0, 0, types.BlockID{}, nil)
-	block, _ := blockExec.CreateProposalBlock(
+	blockExec.CreateProposalBlock(
 		1,
 		state, commit,
 		proposerAddr,
 	)
 	assert.EqualValues(t, 1, mempool.TxsBytes())
-	err = blockExec.ValidateBlock(state, block)
+	tx, err := mempool.GetNextTxBytes(2, 1, nil)
 	assert.NoError(t, err)
+	assert.EqualValues(t, []byte{0x03}, tx)
 }
 
 func TestApplyBlock(t *testing.T) {


### PR DESCRIPTION
Invalid txs included in ResponseCreateBlock will be eliminated from mempool in function `CreateProposalBlock`.

Resolves issue #28 