### PR TITLE
[abcix-mempool] Add UpdateKey interface to LLRB

### DIFF
--- a/libs/llrb/interface.go
+++ b/libs/llrb/interface.go
@@ -1,10 +1,16 @@
 package llrb
 
-import "time"
+import (
+	"crypto/sha256"
+	"time"
+)
+
+const TxKeySize = sha256.Size
 
 type NodeKey struct {
 	Priority uint64
 	TS       time.Time
+	TxHash   [TxKeySize]byte
 }
 
 type LLRB interface {

--- a/libs/llrb/interface.go
+++ b/libs/llrb/interface.go
@@ -5,12 +5,10 @@ import (
 	"time"
 )
 
-const TxKeySize = sha256.Size
-
 type NodeKey struct {
 	Priority uint64
 	TS       time.Time
-	TxHash   [TxKeySize]byte
+	Hash     [sha256.Size]byte
 }
 
 type LLRB interface {

--- a/libs/llrb/interface.go
+++ b/libs/llrb/interface.go
@@ -12,7 +12,7 @@ type LLRB interface {
 	GetNext(starter *NodeKey, predicate func(interface{}) bool) (interface{}, error)
 	Insert(key NodeKey, data interface{}) error
 	Remove(key NodeKey) (interface{}, error)
-	Update(oldKey NodeKey, newKey NodeKey) error
+	UpdateKey(oldKey NodeKey, newKey NodeKey) error
 }
 
 func New() LLRB {

--- a/libs/llrb/interface.go
+++ b/libs/llrb/interface.go
@@ -12,6 +12,7 @@ type LLRB interface {
 	GetNext(starter *NodeKey, predicate func(interface{}) bool) (interface{}, error)
 	Insert(key NodeKey, data interface{}) error
 	Remove(key NodeKey) (interface{}, error)
+	Update(oldKey NodeKey, newKey NodeKey) error
 }
 
 func New() LLRB {

--- a/libs/llrb/llrb.go
+++ b/libs/llrb/llrb.go
@@ -82,16 +82,12 @@ func (t *llrb) GetNext(starter *NodeKey, predicate func(interface{}) bool) (inte
 	return candidate.data, nil
 }
 
-func (t *llrb) Update(oldKey NodeKey, newKey NodeKey) error {
-	data, err := t.Remove(oldKey)
-	if err != nil {
+func (t *llrb) UpdateKey(oldKey NodeKey, newKey NodeKey) error {
+	if data, err := t.Remove(oldKey); err != nil {
 		return err
+	} else {
+		return t.Insert(newKey, data)
 	}
-	err = t.Insert(newKey, data)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // Insert inserts value into the tree

--- a/libs/llrb/llrb.go
+++ b/libs/llrb/llrb.go
@@ -27,7 +27,7 @@ func (a NodeKey) compare(b NodeKey) int {
 	if a.TS.After(b.TS) {
 		return -1
 	}
-	return bytes.Compare(a.TxHash[:], b.TxHash[:])
+	return bytes.Compare(a.Hash[:], b.Hash[:])
 }
 
 type node struct {

--- a/libs/llrb/llrb.go
+++ b/libs/llrb/llrb.go
@@ -1,6 +1,7 @@
 package llrb
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -26,7 +27,7 @@ func (a NodeKey) compare(b NodeKey) int {
 	if a.TS.After(b.TS) {
 		return -1
 	}
-	return 0
+	return bytes.Compare(a.TxHash[:], b.TxHash[:])
 }
 
 type node struct {

--- a/libs/llrb/llrb.go
+++ b/libs/llrb/llrb.go
@@ -83,11 +83,11 @@ func (t *llrb) GetNext(starter *NodeKey, predicate func(interface{}) bool) (inte
 }
 
 func (t *llrb) UpdateKey(oldKey NodeKey, newKey NodeKey) error {
-	if data, err := t.Remove(oldKey); err != nil {
+	data, err := t.Remove(oldKey)
+	if err != nil {
 		return err
-	} else {
-		return t.Insert(newKey, data)
 	}
+	return t.Insert(newKey, data)
 }
 
 // Insert inserts value into the tree

--- a/libs/llrb/llrb.go
+++ b/libs/llrb/llrb.go
@@ -11,6 +11,7 @@ import (
 const maxSize = int(^uint(0) >> 1)
 
 var ErrorStopIteration = errors.New("STOP ITERATION")
+var ErrorKeyNotFound = errors.New("KEY NOT FOUND")
 
 func (a NodeKey) compare(b NodeKey) int {
 	if a.Priority > b.Priority {
@@ -79,6 +80,18 @@ func (t *llrb) GetNext(starter *NodeKey, predicate func(interface{}) bool) (inte
 		return nil, ErrorStopIteration
 	}
 	return candidate.data, nil
+}
+
+func (t *llrb) Update(oldKey NodeKey, newKey NodeKey) error {
+	data, err := t.Remove(oldKey)
+	if err != nil {
+		return err
+	}
+	err = t.Insert(newKey, data)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Insert inserts value into the tree
@@ -152,7 +165,7 @@ func (t *llrb) Remove(key NodeKey) (interface{}, error) {
 		t.size--
 		return deleted.data, nil
 	}
-	return nil, fmt.Errorf("key not found")
+	return nil, ErrorKeyNotFound
 }
 
 func (t *llrb) delete(h *node, key NodeKey) (*node, node) {

--- a/libs/llrb/llrb_test.go
+++ b/libs/llrb/llrb_test.go
@@ -130,7 +130,7 @@ func TestLlrb_UpdateKey(t *testing.T) {
 		newKey := *nks[i]
 		newKey.Priority += 100
 		err := tree.UpdateKey(newKey, *nks[i])
-		require.Error(t, err, "expecting error when updating existed keys")
+		require.Error(t, err, "expecting error when updating nonexistent keys")
 		err = tree.UpdateKey(*nks[i], newKey)
 		require.NoError(t, err, "expecting no error when updating existed keys")
 		data, _ := tree.Remove(newKey)

--- a/libs/llrb/llrb_test.go
+++ b/libs/llrb/llrb_test.go
@@ -115,6 +115,29 @@ func TestRandomInsertDeleteNonExistent(t *testing.T) {
 	require.Error(t, err, "expecting error when removing nonexistent node")
 }
 
+func TestLlrb_UpdateKey(t *testing.T) {
+	tree := New()
+	n := 100
+	txs := getRandomBytes(n)
+	perm := rand.Perm(n)
+	var nks []*NodeKey
+	for i := 0; i < n; i++ {
+		nk := &NodeKey{Priority: uint64(perm[i])}
+		tree.Insert(*nk, txs[perm[i]])
+		nks = append(nks, nk)
+	}
+	for i := 0; i < n; i++ {
+		newKey := *nks[i]
+		newKey.Priority += 100
+		err := tree.UpdateKey(newKey, *nks[i])
+		require.Error(t, err, "expecting error when updating existed keys")
+		err = tree.UpdateKey(*nks[i], newKey)
+		require.NoError(t, err, "expecting no error when updating existed keys")
+		data, _ := tree.Remove(newKey)
+		require.True(t, bytes.Equal(data.([]byte), txs[perm[i]]), "expecting same tx after updating keys")
+	}
+}
+
 func TestGetNext(t *testing.T) {
 	testCases := []struct {
 		priorities      []uint64 // Priority of each tx

--- a/libs/llrb/llrb_test.go
+++ b/libs/llrb/llrb_test.go
@@ -19,7 +19,7 @@ func getNodeKeys(priorities []uint64, txs [][]byte) []*NodeKey {
 		nk := &NodeKey{
 			Priority: priorities[i],
 			TS:       time.Now(),
-			TxHash:   txHash(txs[i]),
+			Hash:     txHash(txs[i]),
 		}
 		nks = append(nks, nk)
 	}
@@ -36,10 +36,10 @@ func getRandomBytes(count int) [][]byte {
 	return txs
 }
 
-func getFixedBytes(bytelen []int) [][]byte {
+func getFixedBytes(byteLength []int) [][]byte {
 	var txs [][]byte
-	for i := 0; i < len(bytelen); i++ {
-		tx := make([]byte, bytelen[i])
+	for i := 0; i < len(byteLength); i++ {
+		tx := make([]byte, byteLength[i])
 		cr.Read(tx)
 		txs = append(txs, tx)
 	}
@@ -61,7 +61,7 @@ func getOrderedTxs(tree LLRB, byteLimit int, txMap *sync.Map) [][]byte {
 	return txs
 }
 
-func txHash(tx []byte) [TxKeySize]byte {
+func txHash(tx []byte) [sha256.Size]byte {
 	return sha256.Sum256(tx)
 }
 


### PR DESCRIPTION
To handle `CheckTx` with higher priority  #47 , one solution is to delete old key and insert new key, the old key can be found by map from mempool. Considering that two transactions with same priority and time stamp will be considered as same transaction, transaction hash will be added to NodeKey for comparison.